### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/lambda_handler.py
+++ b/lambda_handler.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import io
 import boto3
@@ -67,11 +68,11 @@ def handle_lambda(event,context,called_local=False):
     
     #1/  GET S3 file creation event
     #############################################################333
-    print ("EVENT: "+str(event))
+    print("EVENT: "+str(event))
     bucket_name = event['Records'][0]['s3']['bucket']['name']
     key = urllib.unquote_plus(event['Records'][0]['s3']['object']['key'])
-    print "Using bucket name: "+bucket_name
-    print "Using key: "+key
+    print("Using bucket name: "+bucket_name)
+    print("Using key: "+key)
     
     if not re.search(r'_output\.',key):
         #2/  Call sagemaker endpoint invocation
@@ -82,13 +83,13 @@ def handle_lambda(event,context,called_local=False):
         payload['input']['s3_bucket']=bucket_name
         payload['input']['is_live']=False
     
-        print ("Calling endpoint...")
+        print("Calling endpoint...")
         response = runtime.invoke_endpoint(EndpointName=ENDPOINT_NAME, ContentType='application/json', Body=json.dumps(payload))
-        print ("RESPONSE:")
+        print("RESPONSE:")
         print(response)
         #result = json.loads(response['Body'].read().decode())
     else:
-        print ("New file appears like output: _output -- skipping: "+str(key))
+        print("New file appears like output: _output -- skipping: "+str(key))
     return "Standard response"
 
 

--- a/pothole_base/pothole/mrcnn/model.py
+++ b/pothole_base/pothole/mrcnn/model.py
@@ -2366,7 +2366,7 @@ class MaskRCNN():
         # Work-around for Windows: Keras fails on Windows when using
         # multiprocessing workers. See discussion here:
         # https://github.com/matterport/Mask_RCNN/issues/13#issuecomment-353124009
-        if os.name is 'nt':
+        if os.name == 'nt':
             workers = 0
         else:
             workers = multiprocessing.cpu_count()


### PR DESCRIPTION
Related to #3

Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

flake8 testing of https://github.com/Cyash/Pothole_Detection on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./lambda_handler.py:73:31: E999 SyntaxError: invalid syntax
    print "Using bucket name: "+bucket_name
                              ^
./pothole_base/predictor.py:81:18: F821 undefined name 'predictions'
    for label in predictions:
                 ^
./pothole_base/pothole/mrcnn/model.py:2369:12: F632 use ==/!= to compare str, bytes, and int literals
        if os.name is 'nt':
           ^
1     E999 SyntaxError: invalid syntax
1     F632 use ==/!= to compare str, bytes, and int literals
1     F821 undefined name 'predictions'
3
```